### PR TITLE
feat(formly-form): move `form` out of `formly-form` component.

### DIFF
--- a/demo/template.html
+++ b/demo/template.html
@@ -2,9 +2,11 @@
     <h1>NG2-formly example: Introduction</h1>
     <p>This is a small subset of the things that formly can do :-) See the other examples and the documentation for more.</p>
     <hr>
-    <formly-form [model]="user" [fields]="userFields" (formSubmit)="console($event)" [form]="form">
-        <button type="submit" class="btn btn-primary" (click)="submit(user)">Button</button>
-    </formly-form>
+    <form class="formly" role="form" novalidate [formGroup]="form" (ngSubmit)="submit(user)">
+        <formly-form [model]="user" [fields]="userFields" (formSubmit)="console($event)" [form]="form">
+            <button type="submit" class="btn btn-primary">Button</button>
+        </formly-form>
+    </form>
     <hr>
     <h3>Outside Formly</h3>
     <input type="text" [(ngModel)]="user.email" (keyup)="changeEmail()" class="form-control">

--- a/src/components/formly.form.ts
+++ b/src/components/formly.form.ts
@@ -10,16 +10,14 @@ import {FormlyFieldConfig} from "./formly.field.config";
 @Component({
   selector: "formly-form",
   template: `
-            <form class="formly" role="form" novalidate [formGroup]="form">
-                <formly-field *ngFor="let f of fields"
-                  [hide]="f.hideExpression" [model]="f.key?model[f.key]:model"
-                  [key]="f.key" [form]="form" [field]="f" [formModel]= "model"
-                  (changeFn)="changeFunction($event, f)" [eventEmitter]="event"
-                  [ngClass]="f.className">
-                </formly-field>
-              <ng-content></ng-content>
-            </form>
-            `,
+    <formly-field *ngFor="let f of fields"
+      [hide]="f.hideExpression" [model]="f.key?model[f.key]:model"
+      [key]="f.key" [form]="form" [field]="f" [formModel]= "model"
+      (changeFn)="changeFunction($event, f)" [eventEmitter]="event"
+      [ngClass]="f.className">
+    </formly-field>
+    <ng-content></ng-content>
+  `,
   providers: [FormlyPubSub, SingleFocusDispatcher, FormlyFieldBuilder],
   inputs: ["field", "formModel", "form", "hide", "model"]
 })


### PR DESCRIPTION
Hi,
I would like to use `ngSubmit` and I figured out that is not possible with the current implementation, so I propose to not include `form` in the `formly-form` to allow more flexibility.

thanks in advance :smile: 