### PR TITLE
fix(npmignore): allow `src` folder

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,7 +2,7 @@
 .config
 demo
 node_modules
-src
+coverage
 test
 .editorconfig
 .gitignore

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -18,6 +18,7 @@ import { FieldWrapper } from './templates/field.wrapper';
 import { FormlyGroup } from './components/formly.group';
 
 export {
+  FormlyAttributes,
   FormlyFormBuilder,
   FormlyField,
   FormlyFieldConfig,


### PR DESCRIPTION
**What kind of change does this PR introduce? Bug fix**



**What is the current behavior? https://github.com/formly-js/ng2-formly/issues/239#issuecomment-260175676**

