### PR TITLE
fix(FormlyField): subscribe to FormControl only when field has a key

### DIFF
--- a/src/core/components/formly.field.spec.ts
+++ b/src/core/components/formly.field.spec.ts
@@ -182,6 +182,14 @@ describe('FormlyField Component', () => {
       };
     });
 
+    it('should render field without wrapper or key', () => {
+      delete testComponentInputs.field.key;
+
+      const fixture = createTestComponent('<formly-field [form]="form" [field]="field"></formly-field>');
+      const elm = getFormlyFieldElement(fixture.nativeElement);
+      expect(getInputField(elm)).toBeDefined();
+    });
+
     it('should render field wrapper', () => {
       testComponentInputs.field.wrappers = ['label'];
 

--- a/src/core/components/formly.field.ts
+++ b/src/core/components/formly.field.ts
@@ -73,19 +73,22 @@ export class FormlyField implements DoCheck, OnInit {
         debounce = this.field.modelOptions.debounce.default;
       }
       let fieldComponentRef = this.createFieldComponent();
-      let valueChanges = fieldComponentRef.instance.formControl.valueChanges;
-      if (debounce > 0) {
-        valueChanges = valueChanges.debounceTime(debounce);
-      }
-      if (this.field.parsers && this.field.parsers.length > 0) {
-        this.field.parsers.map(parserFn => {
-          valueChanges = valueChanges.map(parserFn);
-        });
-      }
 
-      valueChanges.subscribe((event) => this
-        .changeModel(new FormlyValueChangeEvent(this.field.key, event))
-      );
+      if (this.field.key) {
+        let valueChanges = fieldComponentRef.instance.formControl.valueChanges;
+        if (debounce > 0) {
+          valueChanges = valueChanges.debounceTime(debounce);
+        }
+        if (this.field.parsers && this.field.parsers.length > 0) {
+          this.field.parsers.map(parserFn => {
+            valueChanges = valueChanges.map(parserFn);
+          });
+        }
+
+        valueChanges.subscribe((event) => this
+          .changeModel(new FormlyValueChangeEvent(this.field.key, event))
+        );
+      }
 
       let update = new FormlyEventEmitter();
       update.subscribe((option: any) => {


### PR DESCRIPTION
**What kind of change does this PR introduce? Bug fix**

