### PR TITLE
feat(#258) valueProp and labelProp in type select

### DIFF
--- a/src/ui-bootstrap/types/select.ts
+++ b/src/ui-bootstrap/types/select.ts
@@ -5,12 +5,14 @@ import { FieldType } from '../../core/core';
   selector: 'formly-field-select',
   template: `
     <select [id]="id" [formControl]="formControl" class="form-control" [formlyAttributes]="field">
-          <option value="" *ngIf="to.placeholder">{{to.placeholder}}</option>
-          <option *ngFor="let option of to.options" [value]="option[to.valueProp || 'value']">
-              {{option[to.labelProp || 'label']}}
-          </option>
-      </select>
+      <option value="" *ngIf="to.placeholder">{{to.placeholder}}</option>
+      <option *ngFor="let option of to.options" [value]="option[valueProp]">
+        {{option[labelProp]}}
+      </option>
+    </select>
   `,
 })
 export class FormlyFieldSelect extends FieldType {
+  get labelProp(): string { return this.to['labelProp'] || 'label'; }
+  get valueProp(): string { return this.to['valueProp'] || 'value'; }
 }

--- a/src/ui-bootstrap/types/select.ts
+++ b/src/ui-bootstrap/types/select.ts
@@ -5,9 +5,11 @@ import { FieldType } from '../../core/core';
   selector: 'formly-field-select',
   template: `
     <select [id]="id" [formControl]="formControl" class="form-control" [formlyAttributes]="field">
-      <option value="" *ngIf="to.placeholder">{{to.placeholder}}</option>
-      <option *ngFor="let option of to.options" [value]="option.value">{{option.label}}</option>
-    </select>
+          <option value="" *ngIf="to.placeholder">{{to.placeholder}}</option>
+          <option *ngFor="let option of to.options" [value]="option[to.valueProp || 'value']">
+              {{option[to.labelProp || 'label']}}
+          </option>
+      </select>
   `,
 })
 export class FormlyFieldSelect extends FieldType {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature


**What is the current behavior? (You can also link to an open issue here)**
[https://github.com/formly-js/ng2-formly/issues/258](#258)


**What is the new behavior (if this is a feature change)?**
adds labelProp and valueProp to template options on the bootstrap select type similar to the angular-formly-templates-bootstrap select type


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:

change select type to use labelProp and valueProp template options (similar to angular-formly-templates-bootstrap)