### PR TITLE
feat(HideExpression) add consistent context to function expression

### DIFF
--- a/src/core/components/formly.field.config.ts
+++ b/src/core/components/formly.field.config.ts
@@ -11,7 +11,7 @@ export interface FormlyFieldConfig {
   wrappers?: string[];
   fieldGroup?: Array<FormlyFieldConfig>;
   fieldArray?: FormlyFieldConfig;
-  hideExpression?: boolean | string | (() => boolean);
+  hideExpression?: boolean | string | ((model, formState) => boolean);
   className?: string;
   type?: string;
   expressionProperties?: any;

--- a/src/core/services/formly.field.delegates.ts
+++ b/src/core/services/formly.field.delegates.ts
@@ -7,7 +7,7 @@ export class FormlyFieldVisibilityDelegate {
   eval(expression: string | Function | boolean): boolean {
     // TODO support this.formlyCommon.field.hideExpression as a observable
     if (expression instanceof Function) {
-      return expression();
+      return expression.apply(this.formlyCommon, [this.formlyCommon.model, this.formlyCommon.options.formState]);
     } else if (typeof expression === 'string') {
       return evalExpression(expression, this.formlyCommon, ['model', 'formState'], [this.formlyCommon.model, this.formlyCommon.options.formState]);
     } else {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature


**What is the current behavior? (You can also link to an open issue here)**
When hideExpression is a function, `this` and `args` of the function are inconsistent with the context when the expression is a string and does not seem to provide useful access to the field.


**What is the new behavior (if this is a feature change)?**
When hideExpression is a function it is called with the same `this` and `args` as it would be if it were a string.


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
This may not be necessary when a hideExpression function is declared in the templateOptions for a field; however, this is intended to address the behavior observed when the hideExpression is declared with a function within the defaultOptions of the formly config.
