### PR TITLE
fix(#282): fixed merge field options with nested property key

### DIFF
--- a/src/core/services/formly.form.builder.spec.ts
+++ b/src/core/services/formly.form.builder.spec.ts
@@ -12,6 +12,7 @@ describe('FormlyFormBuilder service', () => {
     builder = new FormlyFormBuilder(
       new FormlyConfig([{
         types: [{ name: 'input', component: TestComponent }],
+        wrappers: [{ name: 'label', component: TestComponent, types: ['input'] }],
         validators: [{ name: 'required', validation: Validators.required }],
       }], new FormlyUtils()),
       new FormlyUtils()
@@ -57,6 +58,16 @@ describe('FormlyFormBuilder service', () => {
       builder.buildForm(form, [field2], {}, {});
 
       expect(field1['id']).not.toEqual(field2['id']);
+    });
+  });
+
+  describe('merge field options', () => {
+    it('nested property key', () => {
+      field = { key: 'nested.title', type: 'input' };
+      builder.buildForm(form, [field], {}, {});
+
+      expect(field.key).toEqual('nested.title');
+      expect(field.wrappers).toEqual(['label']);
     });
   });
 

--- a/src/core/services/formly.form.builder.ts
+++ b/src/core/services/formly.form.builder.ts
@@ -60,12 +60,10 @@ export class FormlyFormBuilder {
             model[rootPath] = isNaN(rootPath) ? {} : [];
           }
 
-          this.buildForm(
-            nestedForm,
-            [Object.assign({}, field, {key: path})],
-            model[rootPath],
-            {}
-          );
+          const originalKey = field.key;
+          field.key = path;
+          this.buildForm(nestedForm, [field], model[rootPath], {});
+          field.key = originalKey;
         } else {
 
           this.formlyConfig.getMergedField(field);


### PR DESCRIPTION
**What kind of change does this PR introduce? Bug fix**



**What is the current behavior? (You can also link to an open issue here)**
https://github.com/formly-js/ng2-formly/issues/282

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)

