### PR TITLE
Expression properties should be able to take function (#148)

### DIFF
--- a/src/core/components/formly.field.spec.ts
+++ b/src/core/components/formly.field.spec.ts
@@ -110,12 +110,50 @@ describe('FormlyField Component', () => {
     expect(getInputField(fixture.nativeElement, 1).getAttribute('placeholder')).toEqual('Title2');
   });
 
-  it('should hide field', () => {
+  it('should hide field when passed a boolean', () => {
     testComponentInputs = {
       field: {
         key: 'title',
         type: 'text',
         hideExpression: true,
+        templateOptions: {
+          label: 'Title',
+          placeholder: 'Title',
+        },
+      },
+      form: new FormGroup({title: new FormControl()}),
+    };
+
+    const fixture = createTestComponent('<formly-field [form]="form" [field]="field"></formly-field>');
+
+    expect(getFormlyFieldElement(fixture.nativeElement).getAttribute('style')).toEqual('display: none;');
+  });
+
+  it('should hide field when passed a string', () => {
+    testComponentInputs = {
+      field: {
+        key: 'title',
+        type: 'text',
+        hideExpression: 'true',
+        templateOptions: {
+          label: 'Title',
+          placeholder: 'Title',
+        },
+      },
+      form: new FormGroup({title: new FormControl()}),
+    };
+
+    const fixture = createTestComponent('<formly-field [form]="form" [field]="field"></formly-field>');
+
+    expect(getFormlyFieldElement(fixture.nativeElement).getAttribute('style')).toEqual('display: none;');
+  });
+
+  it('should hide field when passed a function', () => {
+    testComponentInputs = {
+      field: {
+        key: 'title',
+        type: 'text',
+        hideExpression: () => true,
         templateOptions: {
           label: 'Title',
           placeholder: 'Title',

--- a/src/core/components/formly.field.ts
+++ b/src/core/components/formly.field.ts
@@ -22,7 +22,7 @@ export class FormlyField implements DoCheck, OnInit {
   @Input() model: any;
   @Input() form: FormGroup;
   @Input() field: FormlyFieldConfig;
-  @Input() options;
+  @Input() options: any = {};
   @Input()
   get hide() { return this._hide; }
   set hide(value: boolean) {

--- a/src/core/services/formly.expression.ts
+++ b/src/core/services/formly.expression.ts
@@ -1,8 +1,18 @@
-export function evalExpression(expression: string, thisArg: any, argNames: string[], argVal: any[]) {
+function evalStringExpression(expression: string, thisArg: any, argNames: string[], argVal: any[]) {
   try {
     return Function.bind.apply(Function, [void 0].concat(argNames.concat(`return ${expression};`)))().apply(thisArg, argVal);
   } catch (error) {
     console.error(error);
+  }
+}
+
+export function evalExpression(expression: string | Function | boolean, thisArg: any, argNames: string[], argVal: any[]): boolean {
+  if (expression instanceof Function) {
+    return expression.apply(thisArg, argVal);
+  } else if (typeof expression === 'string') {
+    return evalStringExpression(expression, thisArg, argNames, argVal);
+  } else {
+    return expression ? true : false;
   }
 }
 

--- a/src/core/services/formly.field.delegates.ts
+++ b/src/core/services/formly.field.delegates.ts
@@ -4,24 +4,16 @@ import { FormlyField } from '../components/formly.field';
 export class FormlyFieldVisibilityDelegate {
   constructor(private formlyCommon: FormlyField) {}
 
-  eval(expression: string | Function | boolean): boolean {
-    // TODO support this.formlyCommon.field.hideExpression as a observable
-    if (expression instanceof Function) {
-      return expression.apply(this.formlyCommon, [this.formlyCommon.model, this.formlyCommon.options.formState]);
-    } else if (typeof expression === 'string') {
-      return evalExpression(expression, this.formlyCommon, ['model', 'formState'], [this.formlyCommon.model, this.formlyCommon.options.formState]);
-    } else {
-      return expression ? true : false;
-    }
-  }
-
   hasHideExpression(): boolean {
     return (this.formlyCommon.field && this.formlyCommon.field.hideExpression !== undefined) && this.formlyCommon.field.hideExpression ? true : false;
   }
 
   checkVisibilityChange() {
     if (this.hasHideExpression()) {
-      let hideExpressionResult: boolean = this.eval(this.formlyCommon.field.hideExpression);
+      let hideExpressionResult: boolean = evalExpression(this.formlyCommon.field.hideExpression
+        , this.formlyCommon, ['model', 'formState']
+        , [this.formlyCommon.model, this.formlyCommon.options.formState]);
+
       if (hideExpressionResult !== this.formlyCommon.hide) {
         this.formlyCommon.hide = hideExpressionResult;
       }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Feature


**What is the current behavior? (You can also link to an open issue here)**
ExpressionProperties only accept strings - see #148 


**What is the new behavior (if this is a feature change)?**
ExpressionProperties accept strings, booleans and functions - as hideExpression