### PR TITLE
fix(reset) FormArray reset

### DIFF
--- a/demo/repeatedSection.ts
+++ b/demo/repeatedSection.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { FieldType, FormlyFieldConfig } from '../src/index';
+import { clone } from '../src/core/utils';
 
 @Component({
   selector: 'formly-repeat-section',
@@ -9,7 +10,7 @@ import { FieldType, FormlyFieldConfig } from '../src/index';
       <formly-form
         [model]="model[i]"
         [fields]="fields"
-        [options]="options"
+        [options]="newOptions"
         [form]="control"
         [ngClass]="field.fieldArray.className">
       </formly-form>
@@ -23,6 +24,10 @@ import { FieldType, FormlyFieldConfig } from '../src/index';
   `,
 })
 export class RepeatComponent extends FieldType implements OnInit {
+
+  get newOptions() {
+    return clone(this.options);
+  }
   get controls() {
     return this.form.controls[this.field.key]['controls'];
   }

--- a/src/core/components/formly.field.spec.ts
+++ b/src/core/components/formly.field.spec.ts
@@ -299,7 +299,7 @@ class TestComponent {
   selector: 'formly-field-text',
   template: `<input type="text" [formControl]="formControl" [formlyAttributes]="field">`,
 })
-class FormlyFieldText extends FieldType {}
+export class FormlyFieldText extends FieldType {}
 
 @Component({
   selector: 'formly-wrapper-label',

--- a/src/core/components/formly.form.spec.ts
+++ b/src/core/components/formly.form.spec.ts
@@ -1,22 +1,118 @@
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { createGenericTestComponent } from '../test-utils';
+import { FormlyWrapperLabel, FormlyFieldText } from './formly.field.spec';
 
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FormlyModule } from '../core';
+import { FormGroup } from '@angular/forms';
+import { FieldType } from '../templates/field.type';
+import { clone } from '../utils';
+import { FormlyFieldConfig } from './formly.field.config';
 
 const createTestComponent = (html: string) =>
     createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
+let testComponentInputs;
+
 describe('Formly Form Component', () => {
   beforeEach(() => {
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [FormlyModule.forRoot()]});
+    TestBed.configureTestingModule({declarations: [TestComponent, FormlyFieldText, FormlyWrapperLabel, RepeatComponent], imports: [FormlyModule.forRoot({
+      types: [
+        {
+          name: 'text',
+          component: FormlyFieldText,
+        },
+        {
+          name: 'other',
+          component: FormlyFieldText,
+          wrappers: ['label'],
+        },
+        {
+          name: 'repeat',
+          component: RepeatComponent,
+        },
+      ],
+      wrappers: [{
+        name: 'label',
+        component: FormlyWrapperLabel,
+      }],
+    })]});
   });
 
   it('should initialize inputs with default values', () => {
-    createTestComponent('<formly-form></formly-form>');
+    testComponentInputs = {
+      fields: [{
+        fieldGroup: [{
+          key: 'name',
+          type: 'text',
+        }],
+      }, {
+        key: 'investments',
+        type: 'repeat',
+        fieldArray: {
+          fieldGroup: [{
+            key: 'investmentName',
+            type: 'text',
+          }],
+        },
+      }],
+      form: new FormGroup({}),
+      options: {},
+      model: {
+        investments: [{investmentName: 'FA'}, {}],
+      },
+    };
+    createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>');
+    testComponentInputs.form.controls.investments.removeAt(1);
+    testComponentInputs.options.resetModel();
   });
 });
 
 @Component({selector: 'formly-form-test', template: '', entryComponents: []})
 class TestComponent {
+  fields = testComponentInputs.fields;
+  form = testComponentInputs.form;
+  model = testComponentInputs.model || {};
+  options = testComponentInputs.options;
+}
+
+@Component({
+  selector: 'formly-repeat-section',
+  template: `
+    <div *ngFor="let control of controls; let i = index;">
+      <formly-form
+        [model]="model[i]"
+        [fields]="fields"
+        [options]="newOptions"
+        [form]="control">
+      </formly-form>
+      <button (click)="remove(i)">Remove</button>
+    </div>
+  `,
+})
+export class RepeatComponent extends FieldType implements OnInit {
+  get newOptions() {
+    return clone(this.options);
+  }
+  get controls() {
+    return this.form.controls[this.field.key]['controls'];
+  }
+
+  get fields(): FormlyFieldConfig[] {
+    return this.field.fieldArray.fieldGroup;
+  }
+
+  remove(i) {
+    this.form.controls[this.field.key]['controls'].splice(i, 1);
+    this.model.splice(i, 1);
+  }
+
+  ngOnInit() {
+    if (this.model) {
+      this.model.map(() => {
+        let formGroup = new FormGroup({});
+        this.form.controls[this.field.key]['controls'].push(formGroup);
+      });
+    }
+  }
 }

--- a/src/core/components/formly.form.ts
+++ b/src/core/components/formly.form.ts
@@ -1,9 +1,10 @@
 import { Component, OnChanges, Input, SimpleChanges } from '@angular/core';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, FormArray } from '@angular/forms';
 import { FormlyValueChangeEvent } from './../services/formly.event.emitter';
 import { FormlyFieldConfig } from './formly.field.config';
 import { FormlyFormBuilder } from '../services/formly.form.builder';
 import { assignModelValue } from './../utils';
+import { reverseDeepMerge, getKey, getValueForKey } from '../utils';
 
 @Component({
   selector: 'formly-form',
@@ -62,9 +63,45 @@ export class FormlyForm implements OnChanges {
 
   private resetModel() {
     this.form.patchValue(this.initialModel);
+    this.resetFormGroup(this.form);
+  }
+
+  private resetFormGroup(form: FormGroup, actualKey?: string) {
+    for (let controlKey in form.controls) {
+      if (form.controls[controlKey] instanceof FormGroup) {
+        this.resetFormGroup(<FormGroup>form.controls[controlKey], getKey(controlKey, actualKey));
+      }
+      if (form.controls[controlKey] instanceof FormArray) {
+        this.resetArray(<FormArray>form.controls[controlKey], getKey(controlKey, actualKey));
+      }
+    }
+  }
+
+  private resetArray(formArray: FormArray, key: string) {
+    for (let i in formArray.controls) {
+      if  (formArray.controls[i] instanceof FormGroup && getValueForKey(this.initialModel, key)[i]) {
+        formArray.controls[i].patchValue(getValueForKey(this.initialModel, key)[i]);
+      } else if (formArray.controls[i] instanceof FormGroup && !getValueForKey(this.initialModel, key)[i]) {
+        formArray.removeAt(parseInt(i, 10));
+        getValueForKey(this.model, key).splice(i, 1);
+      }
+    }
+    if (formArray.controls.length < getValueForKey(this.initialModel, key).length) {
+      let remaining = getValueForKey(this.initialModel, key).length - formArray.controls.length;
+      let initialLength = formArray.controls.length;
+      for (let i = 0; i < remaining; i++) {
+        let pos = initialLength + i;
+        formArray.setControl(pos, new FormGroup({}));
+        setTimeout(() => {
+          getValueForKey(this.model, key).push(getValueForKey(this.initialModel, key)[pos]);
+          formArray.controls[pos].setValue(getValueForKey(this.initialModel, key)[pos]);
+        });
+      }
+    }
   }
 
   private updateInitialValue() {
-    this.initialModel = Object.assign({}, this.form.value);
+    let obj = reverseDeepMerge(this.form.value, this.model);
+    this.initialModel = JSON.parse(JSON.stringify(obj));
   }
 }

--- a/src/core/components/formly.group.ts
+++ b/src/core/components/formly.group.ts
@@ -1,14 +1,20 @@
 import { Component } from '@angular/core';
 import { AbstractControl } from '@angular/forms';
 import { FieldType } from '../templates/field.type';
+import { clone } from '../utils';
 
 @Component({
   selector: 'formly-group',
   template: `
-    <formly-form [fields]="field.fieldGroup" [model]="model" [form]="formlyGroup" [options]="options" [ngClass]="field.className"></formly-form>
+    <formly-form [fields]="field.fieldGroup" [model]="model" [form]="formlyGroup" [options]="newOptions" [ngClass]="field.className"></formly-form>
   `,
 })
 export class FormlyGroup extends FieldType {
+
+  get newOptions() {
+    return clone(this.options);
+  }
+
   get formlyGroup(): AbstractControl {
     if (this.field.key) {
       return this.form.get(this.field.key);

--- a/src/core/services/formly.form.builder.ts
+++ b/src/core/services/formly.form.builder.ts
@@ -13,7 +13,7 @@ export class FormlyFormBuilder {
 
   constructor(private formlyConfig: FormlyConfig) {}
 
-  buildForm(form: FormGroup, fields: FormlyFieldConfig[], model, options) {
+  buildForm(form: FormGroup, fields: FormlyFieldConfig[] = [], model, options) {
     this.model = model;
     this.formId++;
     let fieldTransforms = (options && options.fieldTransform) || this.formlyConfig.extras.fieldTransform;

--- a/src/core/utils.spec.ts
+++ b/src/core/utils.spec.ts
@@ -1,4 +1,4 @@
-import { reverseDeepMerge, assignModelValue, getFieldId } from './utils';
+import { reverseDeepMerge, assignModelValue, getFieldId, getValueForKey, getKey, evalExpression } from './utils';
 import { FormlyFieldConfig } from './components/formly.field.config';
 
 describe('FormlyUtils service', () => {
@@ -21,6 +21,23 @@ describe('FormlyUtils service', () => {
     });
   });
 
+  describe('getValueForKey', () => {
+    it('should properly get value', () => {
+      let model = {
+        value: 2,
+      };
+      expect(getValueForKey(model, 'path.to.save')).toBe(undefined);
+      expect(getValueForKey(model, 'value')).toBe(2);
+    });
+  });
+
+  describe('getKey', () => {
+    it('should properly get key', () => {
+      expect(getKey('key', 'path.to.save')).toBe('path.to.save.key');
+      expect(getKey('key', undefined)).toBe('key');
+    });
+  });
+
   describe('getFieldId', () => {
     it('should properly get the field id if id is set in options', () => {
       let options: FormlyFieldConfig = {id: '1'};
@@ -32,6 +49,16 @@ describe('FormlyUtils service', () => {
       let options: FormlyFieldConfig = {type: 'input', key: 'email'};
       let id = getFieldId('formly_1', options, 2);
       expect(id).toBe('formly_1_input_email_2');
+    });
+  });
+
+  describe('evalExpression', () => {
+    it('should evaluate the value correctly', () => {
+      let expression = () => { return this.model.val; };
+      this.model = {
+        val: 2,
+      };
+      expect(evalExpression(expression, this, [this.model])).toBe(2);
     });
   });
 });

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -23,6 +23,25 @@ export function assignModelValue(model, path, value) {
   }
 }
 
+export function getValueForKey(model, path) {
+  if (typeof path === 'string') {
+    path = path.split('.');
+  }
+  if (path.length > 1) {
+    const e = path.shift();
+    if (!model[e]) {
+      model[e] = isNaN(path[0]) ? {} : [];
+    }
+    getValueForKey(model[e], path);
+  } else {
+    return model[path[0]];
+  }
+}
+
+export function getKey(controlKey: string, actualKey: string) {
+  return actualKey ? actualKey + '.' + controlKey : controlKey;
+}
+
 export function reverseDeepMerge(dest, source = undefined) {
   let args = Array.prototype.slice.call(arguments);
   if (!args[1]) {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
fix #288 


**What is the current behavior? (You can also link to an open issue here)**
Can't reset RepeatSection


**What is the new behavior (if this is a feature change)?**
Reset of FormArray in the this.form 


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:

