### PR TITLE
feat(resetModel): update options.resetModel to accept an optional model

### DIFF
--- a/demo/hello.ts
+++ b/demo/hello.ts
@@ -466,6 +466,41 @@ export class HelloApp {
     });
   }
 
+  resetModelWithModel() {
+    this.options.resetModel({
+      checked: true,
+      title1: 'mrs',
+      toggleVal: false,
+      interest: {
+        sports: true,
+      },
+      investments: [
+        {
+          investmentName: 'Formly',
+          investmentDate: '02-11-2001',
+          stockIdentifier: 'FO',
+        }, {
+          investmentName: 'Formly Website',
+          investmentDate: '02-11-2001',
+          stockIdentifier: 'FW',
+        }, {
+          investmentName: 'Alphabet',
+          investmentDate: '12-02-2016',
+          stockIdentifier: 'GOOGL',
+        },
+      ],
+      nested: {
+        property: {
+          magic: 'look what I can do',
+        },
+        arrays: {
+          0: 'why not?',
+        },
+      },
+      unbound: 'not bound in formly',
+    });
+  }
+
   submit(user) {
     console.log(user);
   }

--- a/demo/repeatedSection.ts
+++ b/demo/repeatedSection.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { FormGroup } from '@angular/forms';
+import { AbstractControl, FormArray, FormGroup } from '@angular/forms';
 import { FieldType, FormlyFieldConfig } from '../src/index';
 import { clone } from '../src/core/utils';
 
@@ -28,8 +28,9 @@ export class RepeatComponent extends FieldType implements OnInit {
   get newOptions() {
     return clone(this.options);
   }
-  get controls() {
-    return this.form.controls[this.field.key]['controls'];
+
+  get controls(): AbstractControl[] {
+    return (<FormArray>this.form.get(this.field.key)).controls;
   }
 
   get fields(): FormlyFieldConfig[] {
@@ -40,18 +41,19 @@ export class RepeatComponent extends FieldType implements OnInit {
     if (this.model) {
       this.model.map(() => {
         let formGroup = new FormGroup({});
-        this.form.controls[this.field.key]['controls'].push(formGroup);
+        this.controls.push(formGroup);
       });
     }
   }
+
   add() {
     let formGroup = new FormGroup({});
     this.model.push({});
-    this.form.controls[this.field.key]['controls'].push(formGroup);
+    this.controls.push(formGroup);
   }
 
   remove(i) {
-    this.form.controls[this.field.key]['controls'].splice(i, 1);
+    this.controls.splice(i, 1);
     this.model.splice(i, 1);
   }
 }

--- a/demo/template.html
+++ b/demo/template.html
@@ -21,7 +21,9 @@
     <button (click)="showEmail()" class="btn btn-success">Change Email</button>
     <button (click)="resetForm()" class="btn btn-danger">Reset</button>
     <button (click)="hide()" class="btn btn-info">Hide Expression Toggle</button>
-    <button (click)="options.resetModel()" class="btn btn-warning">Reset</button>
+    <button (click)="options.resetModel()" class="btn btn-warning">Reset Model (Initial Values)</button>
+    <button (click)="options.resetModel({})" class="btn btn-warning">Reset Model (Empty Model)</button>
+    <button (click)="resetModelWithModel()" class="btn btn-warning">Reset Model (New Model)</button>
     <button (click)="options.updateInitialValue()" class="btn btn-danger">Update Initial Values</button>
 
 

--- a/src/core/services/formly.form.builder.ts
+++ b/src/core/services/formly.form.builder.ts
@@ -101,12 +101,14 @@ export class FormlyFormBuilder {
       }
 
       if (field.fieldArray && field.key) {
-        const arrayForm = new FormArray(
-          [],
-          field.validators ? field.validators.validation : undefined,
-          field.asyncValidators ? field.asyncValidators.validation : undefined,
-        );
-        form.setControl(field.key, arrayForm);
+        if (!(form.get(field.key) instanceof FormArray)) {
+          const arrayForm = new FormArray(
+            [],
+            field.validators ? field.validators.validation : undefined,
+            field.asyncValidators ? field.asyncValidators.validation : undefined,
+          );
+          form.setControl(field.key, arrayForm);
+        }
       }
     });
   }

--- a/src/core/utils.spec.ts
+++ b/src/core/utils.spec.ts
@@ -25,9 +25,15 @@ describe('FormlyUtils service', () => {
     it('should properly get value', () => {
       let model = {
         value: 2,
+        'looks.nested': 'foo',
+        nested: {
+          value: 'bar',
+        },
       };
       expect(getValueForKey(model, 'path.to.save')).toBe(undefined);
       expect(getValueForKey(model, 'value')).toBe(2);
+      expect(getValueForKey(model, 'looks.nested')).toBe(undefined);
+      expect(getValueForKey(model, 'nested.value')).toBe('bar');
     });
   });
 

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -89,7 +89,7 @@ export function getValueForKey(model, path) {
     if (!model[e]) {
       model[e] = isNaN(path[0]) ? {} : [];
     }
-    getValueForKey(model[e], path);
+    return getValueForKey(model[e], path);
   } else {
     return model[path[0]];
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
feature


**What is the current behavior? (You can also link to an open issue here)**
The repeatSection / fieldArray does not behave well when the model is changed after the form's been built (i.e. bind fields to the form and with a setTimeout bind the model some time later).  Nor does it reset nicely if its key is a path.  See this plunker which uses the latest build of formly:
https://plnkr.co/edit/xXYQcdNFDGj9mcdaoT50?p=preview

**What is the new behavior (if this is a feature change)?**
Updated the form builder's handling of field arrays with the intent of handling paths better.
Updated the form's option.resetModel to accept an optional model to reset the form with; similarly have made efforts to enable this to preserve parts of the model not bound to the form.
Fixed utils.getValueForKey to return the result of its recursive call and added additional tests.


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**
The below pluncker uses this pull request. Please play with this plunker to understand my motivations.
http://plnkr.co/edit/UiwCitsXV5GRtEj9Dsp9?p=preview


**Other information**:
Not sure whether this should be filed under bug fix or feature.  The resetModel seemed more incomplete if anything.
