### PR TITLE
fix: Allow for nested properties in Radiobutton

### DIFF
--- a/demo/hello.ts
+++ b/demo/hello.ts
@@ -330,6 +330,24 @@ export class HelloApp {
           },
         },
       }, {
+        key: 'nested.property.title',
+        type: 'radio',
+        templateOptions: {
+          options: [{
+            key: 'mr',
+            value: 'Mr.',
+          }, {
+            key: 'mrs',
+            value: 'Mrs',
+          }, {
+            key: 'miss',
+            value: 'Miss',
+          }],
+          label: 'Nested Title',
+          description: 'Select a title that suits your description',
+        },
+      },
+      {
         key: 'nested.arrays.0',
         type: 'input',
         templateOptions: {

--- a/src/core/services/formly.form.builder.spec.ts
+++ b/src/core/services/formly.form.builder.spec.ts
@@ -68,6 +68,18 @@ describe('FormlyFormBuilder service', () => {
     });
   });
 
+  describe('form control creation and addition', () => {
+    it('should let component create the form control', () =>  {
+      let field = { key: 'title', type: 'input', component: new TestComponentThatCreatesControl() };
+
+      builder.buildForm(form, [field], {}, {});
+
+      let control: FormControl = <FormControl> form.get('title');
+      expect(control).not.toBeNull();
+      expect(control.value).toEqual('created by component');
+    });
+  });
+
   describe('merge field options', () => {
     it('nested property key', () => {
       field = { key: 'nested.title', type: 'input' };
@@ -200,4 +212,12 @@ describe('FormlyFormBuilder service', () => {
 
 @Component({selector: 'formly-test-cmp', template: '', entryComponents: []})
 class TestComponent {
+}
+
+class TestComponentThatCreatesControl {
+
+  createControl(model, field) {
+    return new FormControl('created by component');
+  }
+
 }

--- a/src/core/services/formly.form.builder.ts
+++ b/src/core/services/formly.form.builder.ts
@@ -53,7 +53,7 @@ export class FormlyFormBuilder {
         if (path.length > 1) {
           const rootPath = path.shift();
           let nestedForm = <FormGroup>(form.get(rootPath) ? form.get(rootPath) : new FormGroup({}, field.validators ? field.validators.validation : undefined, field.asyncValidators ? field.asyncValidators.validation : undefined));
-          if (!form.get(field.key)) {
+          if (!form.get(rootPath)) {
             form.addControl(rootPath, nestedForm);
           }
           if (!model[rootPath]) {
@@ -61,6 +61,7 @@ export class FormlyFormBuilder {
           }
 
           const originalKey = field.key;
+          // Should this reassignment not be refactored?
           field.key = path;
           this.buildForm(nestedForm, [field], model[rootPath], {});
           field.key = originalKey;
@@ -221,10 +222,14 @@ export class FormlyFormBuilder {
   }
 
   private addFormControl(form: FormGroup, field: FormlyFieldConfig, model) {
+    /* Although the type of the key property in FormlyFieldConfig is declared to be a string,
+     the recurstion of this FormBuilder uses an Array.
+     This should probably be addressed somehow. */
+    let name: string = typeof field.key === 'string' ? field.key : field.key[0];
     if (field.component && field.component.createControl) {
-      form.addControl(field.key, field.component.createControl(model, field));
+      form.addControl(name, field.component.createControl(model, field));
     } else {
-      form.addControl(field.key, new FormControl(
+      form.addControl(name, new FormControl(
         { value: model, disabled: field.templateOptions.disabled },
         field.validators ? field.validators.validation : undefined,
         field.asyncValidators ? field.asyncValidators.validation : undefined,

--- a/src/ui-bootstrap/types/radio.ts
+++ b/src/ui-bootstrap/types/radio.ts
@@ -7,7 +7,7 @@ import { FieldType } from '../../core/core';
     <div [formGroup]="form">
       <div *ngFor="let option of to.options" class="radio">
         <label class="custom-control custom-radio">
-          <input [id]="id" type="radio" [value]="option.key" [formControlName]="key"
+          <input [id]="id" [name]="id" type="radio" [value]="option.key" [formControl]="formControl"
           [formlyAttributes]="field" class="custom-control-input">
           {{option.value}}
           <span class="custom-control-indicator"></span>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix


**What is the current behavior? (You can also link to an open issue here)**
#301


**What is the new behavior (if this is a feature change)?**



**Please check if the PR fulfills these requirements**
- [ X] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [X] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [ ] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:

When a Radiobutton control is attached to a nested property, an error is
thrown
 because the formControlName in FormlyField is nested. We fixed this by
using formControl
 instead of formControlName.

We fixed also some more general issues with the FormBuilder and it's
handling of nested
FormGroup and FormControl elements.

(#301)