### PR TITLE
fix(resetModel): update options.resetModel to reset FormArrays correctly

### DIFF
--- a/src/core/components/formly.form.ts
+++ b/src/core/components/formly.form.ts
@@ -101,7 +101,7 @@ export class FormlyForm implements OnChanges {
         this.resetFormGroup(model, <FormGroup>form.controls[controlKey], key);
       }
       if (form.controls[controlKey] instanceof FormArray) {
-        this.resetArray(model, <FormArray>form.controls[controlKey], key);
+        this.resetFormArray(model, <FormArray>form.controls[controlKey], key);
       }
       if (form.controls[controlKey] instanceof FormControl) {
         form.controls[controlKey].setValue(getValueForKey(model, key));
@@ -109,14 +109,14 @@ export class FormlyForm implements OnChanges {
     }
   }
 
-  private resetArray(model: any, formArray: FormArray, key: string) {
+  private resetFormArray(model: any, formArray: FormArray, key: string) {
     let newValue = getValueForKey(model, key);
 
     // removes and updates
-    for (let i = formArray.controls.length - 1; i >= 0; i--) {
-      if (formArray.controls[i] instanceof FormGroup) {
+    for (let i = formArray.length - 1; i >= 0; i--) {
+      if (formArray.at(i) instanceof FormGroup) {
         if (newValue && !isNullOrUndefined(newValue[i])) {
-          this.resetFormGroup(newValue[i], <FormGroup>formArray.controls[i]);
+          this.resetFormGroup(newValue[i], <FormGroup>formArray.at(i));
         }
         else {
           formArray.removeAt(i);
@@ -129,13 +129,13 @@ export class FormlyForm implements OnChanges {
     }
 
     // inserts
-    if (Array.isArray(newValue) && formArray.controls.length < newValue.length) {
-      let remaining = newValue.length - formArray.controls.length;
-      let initialLength = formArray.controls.length;
+    if (Array.isArray(newValue) && formArray.length < newValue.length) {
+      let remaining = newValue.length - formArray.length;
+      let initialLength = formArray.length;
       for (let i = 0; i < remaining; i++) {
         let pos = initialLength + i;
         getValueForKey(this.model, key).push(newValue[pos]);
-        formArray.controls.push(new FormGroup({}));
+        formArray.push(new FormGroup({}));
       }
     }
   }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix


**What is the current behavior? (You can also link to an open issue here)**
When options.resetModel is used to reset the model, parts that would add controls to a FormArray are not updated such that valueChanges would be wired up.


**What is the new behavior (if this is a feature change)?**
The options.resetModel's FormArray reset's been updated to use the FormArray's properties and methods for manipulating its underlying controls as opposed to manipulating the controls array directly.


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Other information**:

fixes issue related to #344 when the options.resetModel is used